### PR TITLE
Ansible 2.7 fix: replace action ec2_facts to ec2_metadata_facts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
     - codedeploy
 
 - name: "Get Instance Metadata | ec2"
-  action: ec2_facts
+  action: ec2_metadata_facts
   tags:
     - codedeploy
 


### PR DESCRIPTION
because no one is merging these upstream